### PR TITLE
add ')' to fix broken delete button

### DIFF
--- a/includes/overrides.php
+++ b/includes/overrides.php
@@ -655,7 +655,7 @@ function pmprommpu_pmpro_membership_levels_table( $intablehtml, $inlevelarr ) {
 										'page'     => 'pmpro-membershiplevels',
 										'action'   => 'delete_membership_level',
 										'deleteid' => $level->id
-									), admin_url( 'admin.php' ) ); ?>'; void(0);"
+									), admin_url( 'admin.php' ) ); ?>'); void(0);"
 									class="button-secondary"><?php _e( 'delete', 'pmpro' ); ?></a></td>
 						</tr>
 						<?php


### PR DESCRIPTION
Initially unable to delete levels. Browser indicated missing ')'.
added ')' to fix broken delete button at line 658, column 107.
tested