### PR TITLE
Fix select and input tags to comply with HTML5 (and cleanups)

### DIFF
--- a/adminpages/level-groups.php
+++ b/adminpages/level-groups.php
@@ -12,8 +12,6 @@
 	else
 		$edit = false;
 
-	//require_once(plugins_url('paid-memberships-pro/adminpages/admin_header.php'));
-
 	$levelgroup = array(
 		'id' => '1',
 		'name' => 'Default',
@@ -55,9 +53,7 @@
 						<select name="type" id="type">
 							<option value="legacy">Users can only choose one level from this group.</option>
 							<option value="multiple">Users can choose multiple levels from this group.</option>
-<!--
-							<option value="super">Super Levels: Users who select these levels will have all other memberships cancelled.</option>
- -->
+							<!-- <option value="super">Super Levels: Users who select these levels will have all other memberships cancelled.</option> -->
 						</select>
 					</td>
 				</tr>

--- a/adminpages/level-groups.php
+++ b/adminpages/level-groups.php
@@ -3,30 +3,27 @@
 	if(!function_exists("current_user_can") || (!current_user_can("manage_options") && !current_user_can("pmpro_membershiplevels")))
 	{
 		die(__("You do not have permissions to perform this action.", 'pmprommpu'));
-	}	
-	
+	}
+
 	global $wpdb, $msg, $msgt;
 
 	if(isset($_REQUEST['edit']))
 		$edit = intval($_REQUEST['edit']);
 	else
 		$edit = false;
-	
-	//require_once(plugins_url('paid-memberships-pro/adminpages/admin_header.php'));		
-?>
 
-<?php	
+	//require_once(plugins_url('paid-memberships-pro/adminpages/admin_header.php'));
 
 	$levelgroup = array(
 		'id' => '1',
 		'name' => 'Default',
 		'type' => 'multiple',
 	);
-	
+
 	if($edit)
-	{			
+	{
 	?>
-		
+
 	<h2>
 		<?php
 			if($edit > 0)
@@ -35,7 +32,7 @@
 				echo __("Add New Level Group", 'pmprommpu');
 		?>
 	</h2>
-		
+
 	<div>
 		<form action="" method="post" enctype="multipart/form-data">
 			<table class="form-table">
@@ -43,37 +40,35 @@
 				<tr>
 					<th scope="row" valign="top"><label><?php _e('ID', 'pmprommpu');?>:</label></th>
 					<td>
-						<?php echo $levelgroup->id?>						
+						<?php echo $levelgroup->id?>
 					</td>
-				</tr>								                
-				
+				</tr>
+
 				<tr>
 					<th scope="row" valign="top"><label for="name"><?php _e('Name', 'pmprommpu');?>:</label></th>
-					<td><input name="name" type="text" size="50" value="<?php echo esc_attr($levelgroup->name);?>" /></td>
+					<td><input name="name" type="text" size="50" value="<?php echo esc_attr($levelgroup->name);?>"></td>
 				</tr>
-				
+
 				<tr>
 					<th scope="row" valign="top"><label for="name"><?php _e('Type', 'pmprommpu');?>:</label></th>
 					<td>
-						<select name="type" id="type" />
+						<select name="type" id="type">
 							<option value="legacy">Users can only choose one level from this group.</option>
-							<option value="multiple">Users can choose multiple levels from this group.</option>		
-<!-- 
+							<option value="multiple">Users can choose multiple levels from this group.</option>
+<!--
 							<option value="super">Super Levels: Users who select these levels will have all other memberships cancelled.</option>
  -->
 						</select>
 					</td>
-				</tr>	
+				</tr>
 			</tbody>
-		</table>				
+		</table>
 		<p class="submit topborder">
-			<input name="save" type="submit" class="button-primary" value="<?php _e('Save Level Group', 'pmprommpu'); ?>" /> 					
-			<input name="cancel" type="button" value="<?php _e('Cancel', 'pmprommpu'); ?>" onclick="location.href='<?php echo add_query_arg( 'page', 'pmpro-membershiplevels', get_admin_url(NULL, 'admin.php') ); ?>';" />
+			<input name="save" type="submit" class="button-primary" value="<?php _e('Save Level Group', 'pmprommpu'); ?>">
+			<input name="cancel" type="button" value="<?php _e('Cancel', 'pmprommpu'); ?>" onclick="location.href='<?php echo add_query_arg( 'page', 'pmpro-membershiplevels', get_admin_url(NULL, 'admin.php') ); ?>';">
 		</p>
 	</form>
 	</div>
-		
+
 	<?php
-	}	
-?>	
-	
+	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -136,7 +136,6 @@ function pmprommpu_get_levels_and_groups_in_order($includehidden = false) {
 
 // Called as a filter by pmpro_pages_custom_template_path to add our path to the search path for user pages.
 function pmprommpu_override_user_pages($templates, $page_name, $type, $where, $ext) {
-
 	if(file_exists(PMPROMMPU_DIR . "/pages/{$page_name}.{$ext}")) {
 		// We add our path as the second in the array - after core, but before user locations.
 		// The array is reversed later, so this means user templates come first, then us, then core.
@@ -424,6 +423,5 @@ function pmprommpu_addMembershipLevel($inlevel = NULL, $user_id = NULL, $force_a
 	}
 
 	// OK, we're legal (or don't care). Let's add it. Set elsewhere by filter, changeMembershipLevel should not disable old levels.
-	$result = pmpro_changeMembershipLevel($levelid, $user_id);
-	return $result;
+	return pmpro_changeMembershipLevel($levelid, $user_id);
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -42,30 +42,30 @@ function pmprommpu_plugin_dir() {
 // Groups have an id, name, displayorder, and flag for allow_multiple_selections
 function pmprommpu_get_groups() {
 	global $wpdb;
-	
+
 	$allgroups = $wpdb->get_results("SELECT * FROM $wpdb->pmpro_groups ORDER BY id");
 	$grouparr = array();
 	foreach($allgroups as $curgroup) {
 		$grouparr[$curgroup->id] = $curgroup;
 	}
-	
+
 	return $grouparr;
 }
 
 // Given a name and a true/false flag about whether it allows multiple selections, create a level group.
 function pmprommpu_create_group($inname, $inallowmult = true) {
 	global $wpdb;
-	
+
 	$allowmult = intval($inallowmult);
 	$result = $wpdb->insert($wpdb->pmpro_groups, array('name' => $inname, 'allow_multiple_selections' => $allowmult), array('%s', '%d'));
-	
+
 	if($result) { return $wpdb->insert_id; } else { return false; }
 }
 
 // Set (or move) a membership level into a level group
 function pmprommpu_set_level_for_group($levelid, $groupid) {
 	global $wpdb;
-	
+
 	$levelid = intval($levelid);
 	$groupid = intval($groupid); // just to be safe
 
@@ -77,9 +77,9 @@ function pmprommpu_set_level_for_group($levelid, $groupid) {
 // Return an array of the groups and levels in display order - keys are group ID, and values are their levels, in display order
 function pmprommpu_get_levels_and_groups_in_order($includehidden = false) {
 	global $wpdb;
-	
+
 	$retarray = array();
-	
+
 	$pmpro_levels = pmpro_getAllLevels($includehidden, true);
 	$pmpro_level_order = pmpro_getOption('level_order');
 	$pmpro_levels = apply_filters('pmpro_levels_array', $pmpro_levels );
@@ -148,9 +148,9 @@ function pmprommpu_override_user_pages($templates, $page_name, $type, $where, $e
 // Given a level ID, this function returns the group ID it belongs to.
 function pmprommpu_get_group_for_level($levelid) {
 	global $wpdb;
-	
+
 	$levelid = intval($levelid); // just to be safe
-	
+
 	$groupid = $wpdb->get_var( $wpdb->prepare( "SELECT mlg.group FROM {$wpdb->pmpro_membership_levels_groups} mlg WHERE level = %d", $levelid ) );
 	if($groupid) {
 		$groupid = intval($groupid);
@@ -163,7 +163,7 @@ function pmprommpu_get_group_for_level($levelid) {
 // Given a level ID and new group ID, this function sets the group ID for a level. Returns a success flag (true/false).
 function pmprommpu_set_group_for_level($levelid, $groupid) {
 	global $wpdb;
-	
+
 	$levelid = intval($levelid); // just to be safe
 	$groupid = intval($groupid); // just to be safe
 
@@ -182,10 +182,10 @@ function pmprommpu_set_group_for_level($levelid, $groupid) {
 // Called by AJAX to add a group from the admin-side Membership Levels and Groups page. Incoming parms are name and mult (can users sign up for multiple levels in this group - 0/1).
 function pmprommpu_add_group() {
 	global $wpdb;
-	
+
 	$displaynum = $wpdb->get_var("SELECT MAX(displayorder) FROM {$wpdb->pmpro_groups}");
 	if(! $displaynum || intval($displaynum)<1) { $displaynum = 1; } else { $displaynum = intval($displaynum); $displaynum++; }
-	
+
 	if(array_key_exists("name", $_REQUEST)) {
 		$allowmult = 0;
 		if(array_key_exists("mult", $_REQUEST) && intval($_REQUEST["mult"])>0) { $allowmult = 1; }
@@ -198,14 +198,14 @@ function pmprommpu_add_group() {
 					'%d')
 			);
 	}
-	
+
 	wp_die();
 }
 
 // Called by AJAX to edit a group from the admin-side Membership Levels and Groups page. Incoming parms are group (the ID #), name and mult (can users sign up for multiple levels in this group - 0/1).
 function pmprommpu_edit_group() {
 	global $wpdb;
-	
+
 	if(array_key_exists("name", $_REQUEST) && array_key_exists("group", $_REQUEST) && intval($_REQUEST["group"])>0) {
 		$allowmult = 0;
 		if(array_key_exists("mult", $_REQUEST) && intval($_REQUEST["mult"])>0) { $allowmult = 1; }
@@ -224,14 +224,14 @@ function pmprommpu_edit_group() {
 			array(	'%d' ) // WHERE format
 		);
 	}
-	
+
 	wp_die();
 }
 
 // Called by AJAX to delete an empty group from the admin-side Membership Levels and Groups page. Incoming parm is group (group ID #).
 function pmprommpu_del_group() {
 	global $wpdb;
-	
+
 	if(array_key_exists("group", $_REQUEST) && intval($_REQUEST["group"])>0) {
 		$groupid = intval($_REQUEST["group"]);
 
@@ -239,17 +239,17 @@ function pmprommpu_del_group() {
 		$wpdb->delete( $wpdb->pmpro_membership_levels_groups, array('group' => $groupid ) );
 		$wpdb->delete( $wpdb->pmpro_groups, array( 'id' => $groupid) );
 	}
-	
+
 	wp_die();
 }
 
 // Called by AJAX from the admin-facing levels page when the rows are reordered. Incoming parm (neworder) is an ordered array of objects (with two parms, group (scalar ID) and levels (ordered array of scalar level IDs))
 function pmprommpu_update_level_and_group_order() {
 	global $wpdb;
-	
+
 	$grouparr = array();
 	$levelarr = array();
-	
+
 	if(array_key_exists("neworder", $_REQUEST) && is_array($_REQUEST["neworder"])) {
 		foreach($_REQUEST["neworder"] as $curgroup) {
 			$grouparr[] = $curgroup["group"];
@@ -261,14 +261,14 @@ function pmprommpu_update_level_and_group_order() {
 
 		// Inefficient for large groups/large numbers of groups
 		foreach($grouparr as $orderedgroup) {
-			
+
 			// TODO: Error checking would be smart.
 			$wpdb->update( $wpdb->pmpro_groups, array ( 'displayorder' => $ctr ), array( 'id' => $orderedgroup ) );
 			$ctr++;
 		}
 		pmpro_setOption('level_order', $levelarr);
 	}
-	
+
 	wp_die();
 }
 
@@ -277,7 +277,7 @@ function pmprommpu_update_level_and_group_order() {
 // If there are no successful levels, or no checkout, will return an empty array.
 function pmprommpu_get_levels_from_latest_checkout($user_id = NULL, $statuses_to_check = 'success', $checkout_id = -1) {
 	global $wpdb, $current_user;
-	
+
 	if(empty($user_id))
 	{
 		$user_id = $current_user->ID;
@@ -285,7 +285,7 @@ function pmprommpu_get_levels_from_latest_checkout($user_id = NULL, $statuses_to
 
 	if(empty($user_id))
 	{
-		return false;
+		return [];
 	}
 
 	//make sure user id is int for security
@@ -299,7 +299,7 @@ function pmprommpu_get_levels_from_latest_checkout($user_id = NULL, $statuses_to
 		$checkoutid = $wpdb->get_var("SELECT MAX(checkout_id) FROM $wpdb->pmpro_membership_orders WHERE user_id=$user_id");
 		if(empty($checkoutid) || intval($checkoutid)<1) { return $retval; }
 	}
-	
+
 	$querySql = "SELECT membership_id FROM $wpdb->pmpro_membership_orders WHERE checkout_id = " . esc_sql( $checkoutid ) . " AND ( gateway = 'free' OR ";
 	if(!empty($statuses_to_check) && is_array($statuses_to_check)) {
 		$querySql .= "status IN('" . implode("','", $statuses_to_check) . "') ";
@@ -309,7 +309,7 @@ function pmprommpu_get_levels_from_latest_checkout($user_id = NULL, $statuses_to
 		$querySql .= "status = 'success'";
 	}
 	$querySql .= " )";
-		
+
 	$levelids = $wpdb->get_col($querySql);
 	foreach($levelids as $thelevel) {
 		if(array_key_exists($thelevel, $all_levels)) {
@@ -323,7 +323,7 @@ function pmprommpu_join_with_and($inarray) {
 	$outstring = "";
 
 	if(!is_array($inarray) || count($inarray)<1) { return $outstring; }
-	
+
 	$lastone = array_pop($inarray);
 	if(count($inarray)>0) {
 		$outstring .= implode(', ', $inarray);
@@ -347,20 +347,20 @@ function pmprommpu_hasMembershipGroup($groups = NULL, $user_id = NULL) {
 	if(empty($user_id)) {
 		$user_id = $current_user->ID;
 	}
-	
+
 	//get membership levels (or not) for given user
-	if(!empty($user_id) && is_numeric($user_id)) 
+	if(!empty($user_id) && is_numeric($user_id))
 		$membership_levels = pmpro_getMembershipLevelsForUser($user_id);
 	else
 		$membership_levels = NULL;
-		
+
 	//make an array out of a single element so we can use the same code
 	if(!is_array($groups)) {
 		$groups = array($groups);
 	}
-	
+
 	//no levels, so no groups
-	if(empty($membership_levels)) {		
+	if(empty($membership_levels)) {
 		$return = false;
 	} else {
 		//we have levels, so test against groups given
@@ -374,7 +374,7 @@ function pmprommpu_hasMembershipGroup($groups = NULL, $user_id = NULL) {
 			}
 		}
 	}
-	
+
 	//filter just in case
 	$return = apply_filters("pmprommpu_has_membership_group", $return, $user_id, $groups);
 	return $return;
@@ -409,7 +409,7 @@ function pmprommpu_addMembershipLevel($inlevel = NULL, $user_id = NULL, $force_a
 	} else {
 		$user_id = intval($user_id);
 	}
-	
+
 	$allgroups = pmprommpu_get_groups();
 
 	// OK, we have the user and the level. Let's check to see if adding it is legal. Is it in a group where they can have only one?
@@ -422,7 +422,7 @@ function pmprommpu_addMembershipLevel($inlevel = NULL, $user_id = NULL, $force_a
 			if ( false !== pmpro_hasMembershipLevel( $otherlevels, $user_id ) ) { return $return; }
 		}
 	}
-	
+
 	// OK, we're legal (or don't care). Let's add it. Set elsewhere by filter, changeMembershipLevel should not disable old levels.
 	$result = pmpro_changeMembershipLevel($levelid, $user_id);
 	return $result;

--- a/includes/upgrades.php
+++ b/includes/upgrades.php
@@ -3,23 +3,18 @@
 //	These functions are run on startup if user is an admin. They check for upgrades -
 //	and if it's a new install, everything is an upgrade!
 
-function pmprommpu_setup_and_upgrade()
-{
+function pmprommpu_setup_and_upgrade() {
+	global $wpdb;
+
 	$installed_version = get_option("pmprommpu_version");
 
 	//if we can't find the DB tables, reset version to 0
-	global $wpdb;
 	$wpdb->hide_errors();
 	$wpdb->pmpro_groups = $wpdb->prefix . 'pmpro_groups';
 	$table_exists = $wpdb->query("SHOW TABLES LIKE '" . $wpdb->pmpro_groups . "'");
-	if(!$table_exists)
-		$installed_version = 0;
-
-	//default options
-	if(!$installed_version || $installed_version<1) {
-		$installed_version = pmprommpu_setup_v1();
+	if(!$table_exists || $installed_version < 1) {
+		pmprommpu_setup_v1();
 	}
-
 }
 
 function pmprommpu_db_delta() {
@@ -29,30 +24,25 @@ function pmprommpu_db_delta() {
 	$wpdb->hide_errors();
 	$wpdb->pmpro_groups = $wpdb->prefix . 'pmpro_groups';
 	$wpdb->pmpro_membership_levels_groups = $wpdb->prefix . 'pmpro_membership_levels_groups';
-	
-	
-	$sqlQuery = "
-		CREATE TABLE `" . $wpdb->pmpro_groups . "` (
-		  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-		  `name` varchar(255) NOT NULL,
-		  `allow_multiple_selections` tinyint(4) NOT NULL DEFAULT '1',
-		  `displayorder` int(11),
-		  PRIMARY KEY (`id`),
-		  KEY `name` (`name`)
-		);
-	";
+
+	$sqlQuery = "CREATE TABLE `" . $wpdb->pmpro_groups . "` (
+		`id` int unsigned NOT NULL AUTO_INCREMENT,
+		`name` varchar(255) NOT NULL,
+		`allow_multiple_selections` tinyint NOT NULL DEFAULT '1',
+		`displayorder` int,
+		PRIMARY KEY (`id`),
+		KEY `name` (`name`)
+	)";
 	dbDelta($sqlQuery);
 
-	$sqlQuery = "
-		CREATE TABLE `" . $wpdb->pmpro_membership_levels_groups . "` (
-		  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-		  `level` int(11) unsigned NOT NULL DEFAULT '0',
-		  `group` int(11) unsigned NOT NULL DEFAULT '0',
-		  PRIMARY KEY (`id`),
-		  KEY `level` (`level`),
-		  KEY `group` (`group`)
-		);
-	";
+	$sqlQuery = "CREATE TABLE `" . $wpdb->pmpro_membership_levels_groups . "` (
+		`id` int unsigned NOT NULL AUTO_INCREMENT,
+		`level` int unsigned NOT NULL DEFAULT '0',
+		`group` int unsigned NOT NULL DEFAULT '0',
+		PRIMARY KEY (`id`),
+		KEY `level` (`level`),
+		KEY `group` (`group`)
+	)";
 	dbDelta($sqlQuery);
 }
 

--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -1,6 +1,6 @@
-<?php 
+<?php
 	global $wpdb, $current_user, $pmpro_invoice, $pmpro_msg, $pmpro_msgt;
-	
+
 	//if membership is a paying one, get invoice from DB - replicating some functionality from the preheader, but with an MMPU spice.
 	$theselevels = pmprommpu_get_levels_from_latest_checkout(NULL, array('success', 'pending'));
 
@@ -15,7 +15,7 @@
 		<div class="pmpro_message <?php echo $pmpro_msgt?>"><?php echo $pmpro_msg?></div>
 	<?php
 	}
-	
+
 	$curlevels = pmpro_getMembershipLevelsForUser();
 	$levelnames = array();
 	$levelnums = array();
@@ -27,9 +27,9 @@
 	if(empty($theselevels)) {
 		$confirmation_message = "<p>" . __('Your payment has been submitted. Your membership will be activated shortly.', 'pmpro') . "</p>";
 	} elseif(count($theselevels) == 1) {
-		$confirmation_message = "<p>" . sprintf(__('Thank you for your membership to %s. Your %s membership is now active.', 'pmpro'), get_bloginfo("name"), pmprommpu_join_with_and($levelnames)) . "</p>";		
+		$confirmation_message = "<p>" . sprintf(__('Thank you for your membership with %s. Your %s membership is now active.', 'pmpro'), get_bloginfo("name"), pmprommpu_join_with_and($levelnames)) . "</p>";
 	} else {
-		$confirmation_message = "<p>" . sprintf(__('Thank you for your membership to %s. Your %s memberships are now active.', 'pmpro'), get_bloginfo("name"), pmprommpu_join_with_and($levelnames)) . "</p>";		
+		$confirmation_message = "<p>" . sprintf(__('Thank you for your membership with %s. Your %s memberships are now active.', 'pmpro'), get_bloginfo("name"), pmprommpu_join_with_and($levelnames)) . "</p>";
 	}
 
 	//confirmation message for this level
@@ -39,28 +39,25 @@
 			$confirmation_message .= "\n" . stripslashes($level_message) . "\n";
 		}
 	}
-?>	
 
-<?php if(!empty($pmpro_invoice) && !empty($pmpro_invoice->id)) { ?>		
-	
-	<?php
+	if(!empty($pmpro_invoice) && !empty($pmpro_invoice->id)) {
+
 		$pmpro_invoice->getUser();
 		$pmpro_invoice->getMembershipLevel();
 
 		$confirmation_message .= "<p>" . sprintf(__('Below are details about your membership account and a receipt for your initial membership invoice. A welcome email with a copy of your initial membership invoice has been sent to %s.', 'pmpro'), $pmpro_invoice->user->user_email) . "</p>";
-		
+
 		//check instructions
 		if($pmpro_invoice->gateway == "check" && !pmpro_areLevelsFree($theselevels))
 			$confirmation_message .= wpautop(pmpro_getOption("instructions"));
-		
-		$confirmation_message = apply_filters("pmpro_confirmation_message", $confirmation_message, $pmpro_invoice);				
-		
-		echo apply_filters("the_content", $confirmation_message);		
+
+		$confirmation_message = apply_filters("pmpro_confirmation_message", $confirmation_message, $pmpro_invoice);
+
+		echo apply_filters("the_content", $confirmation_message);
 	?>
-	
-	
+
 	<h3>
-		<?php printf(__('Invoice #%s on %s', 'pmpro'), $pmpro_invoice->code, date_i18n(get_option('date_format'), $pmpro_invoice->timestamp));?>		
+		<?php printf(__('Invoice #%s on %s', 'pmpro'), $pmpro_invoice->code, date_i18n(get_option('date_format'), $pmpro_invoice->timestamp));?>
 	</h3>
 	<a class="pmpro_a-print" href="javascript:window.print()"><?php _e('Print', 'pmpro');?></a>
 	<ul>
@@ -79,7 +76,7 @@
 		<?php } ?>
 		<?php do_action("pmpro_invoice_bullets_bottom", $pmpro_invoice); ?>
 	</ul>
-	
+
 	<table id="pmpro_confirmation_table" class="pmpro_invoice" width="100%" cellpadding="0" cellspacing="0" border="0">
 		<thead>
 			<tr>
@@ -96,9 +93,9 @@
 				<?php if(!empty($pmpro_invoice->billing->name)) { ?>
 				<td>
 					<?php echo $pmpro_invoice->billing->name?><br />
-					<?php echo $pmpro_invoice->billing->street?><br />						
+					<?php echo $pmpro_invoice->billing->street?><br />
 					<?php if($pmpro_invoice->billing->city && $pmpro_invoice->billing->state) { ?>
-						<?php echo $pmpro_invoice->billing->city?>, <?php echo $pmpro_invoice->billing->state?> <?php echo $pmpro_invoice->billing->zip?> <?php echo $pmpro_invoice->billing->country?><br />												
+						<?php echo $pmpro_invoice->billing->city?>, <?php echo $pmpro_invoice->billing->state?> <?php echo $pmpro_invoice->billing->zip?> <?php echo $pmpro_invoice->billing->country?><br />
 					<?php } ?>
 					<?php echo formatPhone($pmpro_invoice->billing->phone)?>
 				</td>
@@ -111,41 +108,41 @@
 						<?php echo $pmpro_invoice->payment_type?>
 					<?php } ?>
 				</td>
-				<td><?php echo implode('<br>', $levelnames); ?></td>					
+				<td><?php echo implode('<br>', $levelnames); ?></td>
 				<td><?php if($pmpro_invoice->total) echo pmpro_formatPrice($pmpro_invoice->total); else echo "---";?></td>
 			</tr>
 		</tbody>
-	</table>		
-<?php 
-	} 
-	else 
+	</table>
+<?php
+	}
+	else
 	{
 		$confirmation_message .= "<p>" . sprintf(__('Below are details about your membership account. A welcome email has been sent to %s.', 'pmpro'), $current_user->user_email) . "</p>";
-		
+
 		$confirmation_message = apply_filters("pmpro_confirmation_message", $confirmation_message, false);
-		
+
 		echo $confirmation_message;
-	?>	
+	?>
 	<ul>
 		<li><strong><?php _e('Account', 'pmpro');?>:</strong> <?php echo $current_user->display_name?> (<?php echo $current_user->user_email?>)</li>
 		<?php if(count($levelnames)<2) { ?>
 			<li><strong><?php _e('Membership Level', 'pmpro');?>:</strong> <?php if(count($levelnames)==1) echo $levelnames[0]; else _e("Pending", "pmpro");?></li>
-		<?php } else { ?> 
+		<?php } else { ?>
 				<li><strong><?php _e('Membership Levels', 'mmpu'); ?>:</strong><br><span class="pmprommpu_conf_levelrow">
 				<?php echo implode('</span><br><span class="pmprommpu_conf_levelrow">', $levelnames); ?>
 				</span>
 				</li>
 		<?php } ?>
 	</ul>
-<?php 
-	} 
-?>  
+<?php
+	}
+?>
 <nav id="nav-below" class="navigation" role="navigation">
 	<div class="nav-next alignright">
 		<?php if(!empty($curlevels)) { ?>
 			<a href="<?php echo pmpro_url("account")?>"><?php _e('View Your Membership Account &rarr;', 'pmpro');?></a>
-		<?php } else { ?>
-			<?php _e('If your account is not activated within a few minutes, please contact the site owner.', 'pmpro');?>
-		<?php } ?>
+		<?php } else {
+			_e('If your account is not activated within a few minutes, please contact the site owner.', 'pmpro');
+			} ?>
 	</div>
 </nav>

--- a/pmpro-multiple-memberships-per-user.php
+++ b/pmpro-multiple-memberships-per-user.php
@@ -3,7 +3,7 @@
 Plugin Name: Paid Memberships Pro - Multiple Memberships per User
 Plugin URI: http://www.paidmembershipspro.com/pmpro-multiple-memberships-per-user/
 Description: Update PMPro to allow users to checkout for and hold multiple memberships at the same time.
-Version: .4
+Version: .5
 Author: Square Lines LLC and Stranger Studios
 Author URI: http://www.square-lines.com
 */
@@ -46,7 +46,7 @@ Author URI: http://www.square-lines.com
 */
 
 define("PMPROMMPU_DIR", dirname(__FILE__)); // signals our presence to the mother ship, and other add-ons
-define("PMPROMMPU_VER", ".4"); // Version string to signal cache refresh during JS/CSS updates
+define("PMPROMMPU_VER", ".5"); // Version string to signal cache refresh during JS/CSS updates
 
 require_once(PMPROMMPU_DIR . "/includes/upgrades.php");		// to handle upgrades and to do initial setup
 require_once(PMPROMMPU_DIR . "/includes/functions.php");	// misc helper functions
@@ -70,13 +70,13 @@ function pmprommpu_activation() {
 	$curgroups = pmprommpu_get_groups();
 	if(count($curgroups)==0) {
 		$newgroupid = pmprommpu_create_group("Main Group", false);
-		
+
 		$alllevels = pmpro_getAllLevels(true, true);
 		foreach($alllevels as $levelid => $leveldetail) {
 			pmprommpu_set_level_for_group($levelid, $newgroupid);
 		}
 	}
-	
+
 	update_option( 'pmprommpu_installed', 1, true);
 }
 
@@ -87,7 +87,7 @@ function pmprommpu_deactivation() {
 register_activation_hook(__FILE__, 'pmprommpu_activation');
 register_deactivation_hook(__FILE__, 'pmprommpu_deactivation');
 
-//include CSS and styles
+// Include stylesheets.
 function pmprommpu_init() {
 	if(is_admin()) {
 		$csspath = plugins_url("css/jquery-ui.min.css", __FILE__);


### PR DESCRIPTION
This PR fixes a few HTML tags by removing incorrect self-closing slashes.

The other changes showing in the diff are automatic cleanups that any decent IDE should do—trailing spaces at the ends of lines are removed.