### PR TITLE
Update email.php to better handle free levels.

### DIFF
--- a/includes/email.php
+++ b/includes/email.php
@@ -138,6 +138,10 @@ function pmprommpu_send_checkout_emails($user_id, $checkout_id = -1) {
 			else
 				$pmproemail->template = "checkout_paid_admin";
 		}
+		elseif(pmpro_areLevelsFree($levels))
+		{
+			$pmproemail->template = "checkout_free_admin";		
+		}						
 
 		// ...and send it...
 		return $pmproemail->sendEmail();


### PR DESCRIPTION
Issue: MMPU checkouts for free levels were giving white screens instead of confirmations.

Bug: Admin checkout emails for free levels were never getting set.

Resolution: Add condition to MMPU email sending for free levels to use checkout_free_admin template.