### PR TITLE
FIX: Send new/extra Membership level to order

### DIFF
--- a/includes/overrides.php
+++ b/includes/overrides.php
@@ -437,6 +437,8 @@ function pmprommpu_pmpro_after_checkout( $user_id, $checkout_statuses ) {
 				$discount_code_id = "";
 			}
 
+			if($morder->membership_level) {$level = $morder->membership_level;}
+
 			$custom_level = array(
 				'user_id'         => $user_id,
 				'membership_id'   => $level->id,

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -297,6 +297,7 @@ global $current_user;
 		});
 	</script>
 	<?php
+	do_action("pmpro_after_membership_level_profile_fields", $user);
 	}
 }
 


### PR DESCRIPTION
When we are setting up and additional level, make sure we update the order with the new details so we can properly hook in later.

AND New action hook on profile page after modified level selection 