### PR TITLE
Added jquery-migrate to pmprommpu-overrides.js to fix groupallowmult box

### DIFF
--- a/includes/overrides.php
+++ b/includes/overrides.php
@@ -101,6 +101,7 @@ function pmprommpu_addin_jquery_dialog( $pagehook ) {
 		array(
 			'jquery',
 			'jquery-ui-dialog',
+			'jquery-migrate',
 		),
 		PMPROMMPU_VER
 	);


### PR DESCRIPTION
Resolves issue where checkbox to set whether a user can purchase multiple levels from a group would not be saved.