### PR TITLE
Fixed cancellation settings on profile page.

### DIFF
--- a/includes/profile.php
+++ b/includes/profile.php
@@ -375,10 +375,6 @@ function pmprommpu_membership_level_profile_fields_update() {
 
 			//Send cancellation emails.
 			if ( is_array( $_REQUEST['send_cancellation_email'] ) && in_array( $leveltodel, $_REQUEST['send_cancellation_email'] ) ) {
- 				// Email to admin
- 				$pmproemail = new PMProEmail();
- 				$pmproemail->sendCancelEmail( get_userdata($user_id), $leveltodel );
-				
 				// Email to member
  				$pmproemail = new PMProEmail();
  				$pmproemail->sendCancelEmail( get_userdata($user_id), $leveltodel );

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -365,11 +365,11 @@ function pmprommpu_membership_level_profile_fields_update() {
 	if(array_key_exists('remove_levels_id', $_REQUEST)) {
 		foreach($_REQUEST['remove_levels_id'] as $leveltodel) {
 			// Check if we should cancel the subscription at the gateway.
-			if ( ! is_array( $_REQUEST['cancel_subscription'] ) || ! in_array( $leveltodel, $_REQUEST['cancel_subscription'] ) ) {
+			if ( empty( $_REQUEST['cancel_subscription'] ) || ! is_array( $_REQUEST['cancel_subscription'] ) || ! in_array( $leveltodel, $_REQUEST['cancel_subscription'] ) ) {
 				add_filter('pmpro_cancel_previous_subscriptions', 'pmpro_cancel_previous_subscriptions_false');
 			}
 			pmpro_cancelMembershipLevel($leveltodel, $user_id, 'admin_cancelled');
-			if ( ! is_array( $_REQUEST['cancel_subscription'] ) || ! in_array( $leveltodel, $_REQUEST['cancel_subscription'] ) ) {
+			if ( empty( $_REQUEST['cancel_subscription'] ) || ! is_array( $_REQUEST['cancel_subscription'] ) || ! in_array( $leveltodel, $_REQUEST['cancel_subscription'] ) ) {
 				remove_filter('pmpro_cancel_previous_subscriptions', 'pmpro_cancel_previous_subscriptions_false');
 			}
 


### PR DESCRIPTION
Added back functionality for the "Send the user an email about this change" and "Cancel this user's subscription at the gateway" checkboxes when removing their membership level via the WP admin.

There was also a bug where those checkboxes would always target the user's oldest membership level which I resolved by updating the JavaScript. We probably want to look into refactoring all of this in the future.