### PR TITLE
Fix regex when cleaning up the template html

### DIFF
--- a/includes/profile.php
+++ b/includes/profile.php
@@ -121,7 +121,7 @@ global $current_user;
 			<td><a class="remove_level" href="javascript:void(0);"><?php _e('Remove', 'pmprommpu');?></a></td>
 		</tr>
 		<?php
-		$new_level_template_html = preg_replace('/\n\t+/', '', ob_get_contents());
+		$new_level_template_html = preg_replace('/[\n\t]+/', '', ob_get_contents());
 		ob_end_clean();
 
 		//set group for each level


### PR DESCRIPTION
I had an issue with PMPro MMPU, can't say why but on my hosting env with my setup (which was, at the time of writing, the latest PMPro 2.9 + latest PMPro MMPU + WP 6.0) javascript execution was broken by the html template because of the used regex.

This PR wants to switch from `/\n\t+` to `/[\n\t]+`. This means we also want to clean up carriage returns (all of them, even if alone). We just don't want to keep any of \n nor \t, no matter in which order or if they are combined or not.

❌ The old regex says "we want to clean up any \n _followed by_ one or more \t (included)". Not considering any of the \n alone.
✅ The new regex says "we want to clean up any \n OR \t, one or more, no matter in which order.

To simplify and making a comparison:

OLD
<img width="179" alt="Screenshot 2022-07-21 at 12 53 10" src="https://user-images.githubusercontent.com/636911/180198055-1da72411-3f2b-4f97-a1d1-4d227c6ddbd0.png">

NEW
<img width="197" alt="Screenshot 2022-07-21 at 12 53 18" src="https://user-images.githubusercontent.com/636911/180198071-d032efe7-02e7-4340-837a-25d7c2225216.png">

