### PR TITLE
Now always sending admin checkout email

### DIFF
--- a/includes/email.php
+++ b/includes/email.php
@@ -118,9 +118,6 @@ function pmprommpu_send_checkout_emails($user_id, $checkout_id = -1) {
 		$pmproemail->sendEmail();
 	
 		// and we'll modify the fields for the admin checkout e-mail
-		$send = pmpro_getOption("email_admin_checkout");
-		if(empty($send)) { return true; }
-
 		$pmproemail->email = get_bloginfo("admin_email");
 		$pmproemail->subject = sprintf(__("Member Checkout at %s", 'pmpro-multiple-memberships-per-user'), get_option("blogname"));
 		$pmproemail->data['subject'] = $pmproemail->subject;


### PR DESCRIPTION
We have been getting a few support tickets about admin checkout emails not sending when using MMPU. These lines are the cause.

It looks like the idea here is to have a setting where sites could toggle whether or not to send admin checkout emails, but that `pmpro_email_admin_checkout` setting does not appear anywhere else in MMPU. As a result, MMPU sites just never send admin emails.

Instead of trying to add that setting somewhere, this PR just removes that code. If a site wants to disable admin checkout emails, they can do so through the Email Templates settings page.