### PR TITLE
Moving "group" option and fixing saving new level

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -80,7 +80,7 @@ function pmprommpu_get_levels_and_groups_in_order($includehidden = false) {
 
 	$retarray = array();
 
-	$pmpro_levels = pmpro_getAllLevels($includehidden, true);
+	$pmpro_levels = pmpro_getAllLevels($includehidden, false, true);
 	$pmpro_level_order = pmpro_getOption('level_order');
 	$pmpro_levels = apply_filters('pmpro_levels_array', $pmpro_levels );
 

--- a/includes/overrides.php
+++ b/includes/overrides.php
@@ -865,7 +865,6 @@ function pmprommpu_add_group_to_level_options() {
 	$allgroups = pmprommpu_get_groups();
 	$prevgroup = pmprommpu_get_group_for_level( $level );
 	?>
-	<h3 class="topborder"><?php _e( 'Group', 'pmpro-multiple-memberships-per-user' ); ?></h3>
 	<table class="form-table">
 		<tbody>
 		<tr>
@@ -884,7 +883,7 @@ function pmprommpu_add_group_to_level_options() {
 	<?php
 }
 
-add_action( 'pmpro_membership_level_after_other_settings', 'pmprommpu_add_group_to_level_options' );
+add_action( 'pmpro_membership_level_after_general_information', 'pmprommpu_add_group_to_level_options' );
 
 //save options
 function pmprommpu_save_group_on_level_edit( $levelid ) {


### PR DESCRIPTION
This PR has two changes:

1. Moves the "Group" option while editing a membership level to the "general" settings at the top of the page instead of burying it in "Other Settings" (see changes in `includes/overrides.php`)
2. Fixes issue where new levels would always be assigned to first group, regardless of the chosen settings (see change in `includes/functions.php`)