### PR TITLE
Simplifying drag/drop on edit levels page

### DIFF
--- a/js/pmprommpu-overrides.js
+++ b/js/pmprommpu-overrides.js
@@ -150,7 +150,6 @@ jQuery(document).ready(function ($) {
         helper: fixHelper,
         placeholder: 'testclass',
         forcePlaceholderSize: true,
-        connectWith: "tbody",
         update: update_level_and_group_order
     });
 


### PR DESCRIPTION
For a while now, drag and drop did not work to move membership levels between groups. As this bug has caused confusion for many users, this PR disables dragging levels between groups; however, groups can still be reordered by dragging and levels can still be moved within a single group.