### PR TITLE
Additional check added when loading scripts

### DIFF
--- a/includes/overrides.php
+++ b/includes/overrides.php
@@ -131,8 +131,11 @@ function pmprommpu_frontend_scripts() {
 		return;
 	}
 
-	// Only load this on the checkout page
-	if ( is_page( $pmpro_pages['checkout'] ) ) {
+	/**
+	 * Only load this on the checkout page 
+	 * Make sure that the checkout page exists otherwise this fails
+	 */
+	if ( ! empty( $pmpro_pages['checkout'] ) && is_page( $pmpro_pages['checkout'] ) ) {
 
 		global $pmpro_show_discount_code;
 


### PR DESCRIPTION
Adding in an additional check to make sure we only load the pmprommpu-checkout.js script on the PMPro Checkout page. 

If the PMPro Checkout page has not been created, the check gives a false positive and loads the JS - resulting in a JS error loading on other pages 

Resolves #92