### PR TITLE
Updating version of checkout template

### DIFF
--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -1,6 +1,9 @@
 <?php
 /*
- * License:
+ * Template: Checkout
+ * Version: 2.0.2
+
+ License:
 
  Copyright 2016 - Stranger Studios, LLC
 


### PR DESCRIPTION
With PMPro v2.11 enabled, the current version of MMPU shows an outdated template version for the custom checkout page template. This PR updates the template version to resolve this warning.