### PR TITLE
Only load jQuery UI scripts on PMPro Pages

### DIFF
--- a/pmpro-multiple-memberships-per-user.php
+++ b/pmpro-multiple-memberships-per-user.php
@@ -106,15 +106,18 @@ register_deactivation_hook(__FILE__, 'pmprommpu_deactivation');
 // Include stylesheets.
 function pmprommpu_init() {
 	if(is_admin()) {
-		$csspath = plugins_url("css/jquery-ui.min.css", __FILE__);
-		wp_enqueue_style( 'pmprommpu_jquery_ui', $csspath, array(), PMPROMMPU_VER, "screen");
-		$csspath = plugins_url("css/jquery-ui.structure.min.css", __FILE__);
-		wp_enqueue_style( 'pmprommpu_jquery_ui_structure', $csspath, array(), PMPROMMPU_VER, "screen");
-		$csspath = plugins_url("css/jquery-ui.theme.min.css", __FILE__);
-		wp_enqueue_style( 'pmprommpu_jquery_ui_theme', $csspath, array(), PMPROMMPU_VER, "screen");
+		//Only load our scripts on PMPro pages
+		if( ( isset( $_REQUEST['page'] ) && strpos( $_REQUEST['page'], 'pmpro' ) !== false ) ) {				
+			$csspath = plugins_url("css/jquery-ui.min.css", __FILE__);
+			wp_enqueue_style( 'pmprommpu_jquery_ui', $csspath, array(), PMPROMMPU_VER, "screen");
+			$csspath = plugins_url("css/jquery-ui.structure.min.css", __FILE__);
+			wp_enqueue_style( 'pmprommpu_jquery_ui_structure', $csspath, array(), PMPROMMPU_VER, "screen");
+			$csspath = plugins_url("css/jquery-ui.theme.min.css", __FILE__);
+			wp_enqueue_style( 'pmprommpu_jquery_ui_theme', $csspath, array(), PMPROMMPU_VER, "screen");
 
-		$csspath = plugins_url("css/admin.css", __FILE__);
-		wp_enqueue_style( 'pmprommpu_admin', $csspath, array(), PMPROMMPU_VER, "screen");
+			$csspath = plugins_url("css/admin.css", __FILE__);
+			wp_enqueue_style( 'pmprommpu_admin', $csspath, array(), PMPROMMPU_VER, "screen");
+		}
 	} else {
 		$csspath = plugins_url("css/frontend.css", __FILE__);
 		wp_enqueue_style( 'pmprommpu_frontend', $csspath, array(), PMPROMMPU_VER, "screen");


### PR DESCRIPTION
Our jQuery UI scripts load throughout the admin, which causes some formatting issues with other plugins. 

Tested with Gravity forms which caused an issue:

![image](https://github.com/strangerstudios/pmpro-multiple-memberships-per-user/assets/8989542/c7704e69-13be-4a20-b3f1-112e48270692)

With the fix in place

![image](https://github.com/strangerstudios/pmpro-multiple-memberships-per-user/assets/8989542/8ca331eb-0489-41fd-a92b-7ed1ecb369af)

Steps to replicate:
1. Install MMPU and Gravity Forms
2. Create a form - the controls/formatting will be broken
